### PR TITLE
Add pysqlite3-binary dependency

### DIFF
--- a/fridge2table_zero_waste/pyproject.toml
+++ b/fridge2table_zero_waste/pyproject.toml
@@ -7,7 +7,8 @@ requires-python = ">=3.10,<3.14"
 dependencies = [
     "crewai[tools]>=0.141.0,<1.0.0",
     "google-generativeai>=0.3.0",
-    "streamlit>=1.28.0"
+    "streamlit>=1.28.0",
+    "pysqlite3-binary>=0.5.1"
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- include `pysqlite3-binary>=0.5.1` in the project dependencies

## Testing
- `pip install -e fridge2table_zero_waste` *(fails: could not install build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6880006cc2dc83219a78afc1ce0252ab